### PR TITLE
Docs/update api param values

### DIFF
--- a/docs/data-sources/ip.md
+++ b/docs/data-sources/ip.md
@@ -43,7 +43,7 @@ data "cherryservers_ip" "by_address" {
 - `gateway` (String) The gateway IP address.
 - `ptr_record` (String) Reverse DNS name for the IP address.
 - `ptr_record_effective` (String) Reverse DNS name for the IP address. API return value.
-- `region` (String) Slug of the region. Example: eu_nord_1 [See List Regions](https://api.cherryservers.com/doc/#tag/Regions/operation/get-regions).
+- `region` (String) Slug of the region. Example: LT-Siauliai [See List Regions](https://api.cherryservers.com/doc/#tag/Regions/operation/get-regions).
 - `tags` (Map of String) Key/value metadata for server tagging.
 - `target_hostname` (String) The hostname of the server to which the IP is attached.Conflicts with target_id and target_ip_id.
 - `target_id` (String) The ID of the server to which the IP is attached.Conflicts with target_hostname and target_ip_id.

--- a/docs/data-sources/server.md
+++ b/docs/data-sources/server.md
@@ -43,7 +43,7 @@ data "cherryservers_server" "by_hostname" {
 - `os_partition_size` (Number) OS partition size in GB.
 - `plan` (String) Slug of the plan. Example: e5_1620v4. [See List Plans](https://api.cherryservers.com/doc/#tag/Plans/operation/get-plans).
 - `power_state` (String) The power state of the server, such as 'Powered off' or 'Powered on'.
-- `region` (String) Slug of the region. Example: eu_nord_1 [See List Regions](https://api.cherryservers.com/doc/#tag/Regions/operation/get-regions).
+- `region` (String) Slug of the region. Example: LT-Siauliai [See List Regions](https://api.cherryservers.com/doc/#tag/Regions/operation/get-regions).
 - `spot_instance` (Boolean) If True, provisions the server as a spot instance.
 - `ssh_key_ids` (Set of String) Set of the SSH key IDs allowed to SSH to the server.
 - `state` (String) The state of the server, such as 'pending' or 'active'.

--- a/docs/resources/ip.md
+++ b/docs/resources/ip.md
@@ -16,13 +16,13 @@ Provides a CherryServers IP resource. This can be used to create, modify, and de
 # Create a new floating IP address
 resource "cherryservers_ip" "floating-1" {
   project_id = 123456
-  region     = "eu_nord_1"
+  region     = "LT-Siauliai"
 }
 
 # Create a new floating IP address with optional parameters
 resource "cherryservers_ip" "floating-1" {
   project_id      = 123
-  region          = "eu_nord_1"
+  region          = "LT-Siauliai"
   target_hostname = "gentle-turtle"
   ddos_scrubbing  = true
   tags = {
@@ -38,7 +38,7 @@ resource "cherryservers_ip" "floating-1" {
 ### Required
 
 - `project_id` (Number) CherryServers project id, associated with the IP.
-- `region` (String) Slug of the region. Example: eu_nord_1 [See List Regions](https://api.cherryservers.com/doc/#tag/Regions/operation/get-regions).
+- `region` (String) Slug of the region. Example: LT-Siauliai [See List Regions](https://api.cherryservers.com/doc/#tag/Regions/operation/get-regions).
 
 ### Optional
 

--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -17,7 +17,7 @@ Provides a Cherry Servers server resource. This can be used to create, read, mod
 resource "cherryservers_server" "server" {
   plan       = "B1-1-1gb-20s-shared"
   project_id = 123456
-  region     = "eu_nord_1"
+  region     = "LT-Siauliai"
 }
 
 #Create a new server with options:
@@ -25,7 +25,7 @@ resource "cherryservers_server" "server" {
   plan                   = "B1-1-1gb-20s-shared"
   hostname               = "sharing-wallaby"
   project_id             = 123456
-  region                 = "eu_nord_1"
+  region                 = "LT-Siauliai"
   image                  = "ubuntu_22_04"
   ssh_key_ids            = ["1", "2"]
   extra_ip_addresses_ids = ["8269de5d-9b89-af9a-8bcc-8efb4d9fa282"]
@@ -44,7 +44,7 @@ resource "cherryservers_server" "server" {
 
 - `plan` (String) Slug of the plan. Example: e5_1620v4. [See List Plans](https://api.cherryservers.com/doc/#tag/Plans/operation/get-plans).
 - `project_id` (Number) ID of the project to which the server belongs.
-- `region` (String) Slug of the region. Example: eu_nord_1 [See List Regions](https://api.cherryservers.com/doc/#tag/Regions/operation/get-regions).
+- `region` (String) Slug of the region. Example: LT-Siauliai [See List Regions](https://api.cherryservers.com/doc/#tag/Regions/operation/get-regions).
 
 ### Optional
 

--- a/examples/resources/cherryservers_ip/resource.tf
+++ b/examples/resources/cherryservers_ip/resource.tf
@@ -1,13 +1,13 @@
 # Create a new floating IP address
 resource "cherryservers_ip" "floating-1" {
   project_id = 123456
-  region     = "eu_nord_1"
+  region     = "LT-Siauliai"
 }
 
 # Create a new floating IP address with optional parameters
 resource "cherryservers_ip" "floating-1" {
   project_id      = 123
-  region          = "eu_nord_1"
+  region          = "LT-Siauliai"
   target_hostname = "gentle-turtle"
   ddos_scrubbing  = true
   tags = {

--- a/examples/resources/cherryservers_server/resource.tf
+++ b/examples/resources/cherryservers_server/resource.tf
@@ -2,7 +2,7 @@
 resource "cherryservers_server" "server" {
   plan       = "B1-1-1gb-20s-shared"
   project_id = 123456
-  region     = "eu_nord_1"
+  region     = "LT-Siauliai"
 }
 
 #Create a new server with options:
@@ -10,7 +10,7 @@ resource "cherryservers_server" "server" {
   plan                   = "B1-1-1gb-20s-shared"
   hostname               = "sharing-wallaby"
   project_id             = 123456
-  region                 = "eu_nord_1"
+  region                 = "LT-Siauliai"
   image                  = "ubuntu_22_04"
   ssh_key_ids            = ["1", "2"]
   extra_ip_addresses_ids = ["8269de5d-9b89-af9a-8bcc-8efb4d9fa282"]

--- a/internal/provider/ip_data_source.go
+++ b/internal/provider/ip_data_source.go
@@ -57,7 +57,7 @@ func (d *ipDataSource) Schema(ctx context.Context, req datasource.SchemaRequest,
 				Optional:    true,
 			},
 			"region": schema.StringAttribute{
-				Description: "Slug of the region. Example: eu_nord_1 [See List Regions](https://api.cherryservers.com/doc/#tag/Regions/operation/get-regions).",
+				Description: "Slug of the region. Example: LT-Siauliai [See List Regions](https://api.cherryservers.com/doc/#tag/Regions/operation/get-regions).",
 				Computed:    true,
 			},
 			"target_id": schema.StringAttribute{

--- a/internal/provider/ip_data_source_test.go
+++ b/internal/provider/ip_data_source_test.go
@@ -64,7 +64,7 @@ resource "cherryservers_project" "test_ip_project" {
 }
 
 resource "cherryservers_ip" "test_ip_ip" {
-  region = "eu_nord_1"
+  region = "LT-Siauliai"
   project_id = "${cherryservers_project.test_ip_project.id}"
 }
 

--- a/internal/provider/ip_resource.go
+++ b/internal/provider/ip_resource.go
@@ -102,7 +102,7 @@ func (r *ipResource) Schema(ctx context.Context, req resource.SchemaRequest, res
 				},
 			},
 			"region": schema.StringAttribute{
-				Description: "Slug of the region. Example: eu_nord_1 [See List Regions](https://api.cherryservers.com/doc/#tag/Regions/operation/get-regions).",
+				Description: "Slug of the region. Example: LT-Siauliai [See List Regions](https://api.cherryservers.com/doc/#tag/Regions/operation/get-regions).",
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),

--- a/internal/provider/ip_resource_test.go
+++ b/internal/provider/ip_resource_test.go
@@ -20,7 +20,7 @@ func TestAccIPResource_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccIPResourceBasicConfig(projectName, teamId, "eu_nord_1"),
+				Config: testAccIPResourceBasicConfig(projectName, teamId, "LT-Siauliai"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCherryServersIPExists("cherryservers_ip.test_ip_ip"),
 					resource.TestCheckResourceAttrSet("cherryservers_ip.test_ip_ip", "id"),
@@ -42,7 +42,7 @@ func TestAccIPResource_basic(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: testAccIPResourceBasicUpdateConfig(projectName, teamId, "eu_nord_1", aRecord),
+				Config: testAccIPResourceBasicUpdateConfig(projectName, teamId, "LT-Siauliai", aRecord),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("cherryservers_ip.test_ip_ip", "a_record_effective", aRecord+".cloud.cherryservers.net."),
 					resource.TestCheckResourceAttr("cherryservers_ip.test_ip_ip", "ptr_record_effective", "test."),
@@ -108,7 +108,7 @@ resource "cherryservers_project" "test_ip_project" {
 
 resource "cherryservers_server" "test_ip_server" {
   plan = "B1-1-1gb-20s-shared"
-  region = "eu_nord_1"
+  region = "LT-Siauliai"
   project_id = "${cherryservers_project.test_ip_project.id}"
 }
 
@@ -134,13 +134,13 @@ resource "cherryservers_project" "test_ip_project" {
 
 resource "cherryservers_server" "test_ip_server" {
   plan = "B1-1-1gb-20s-shared"
-  region = "eu_nord_1"
+  region = "LT-Siauliai"
   project_id = "${cherryservers_project.test_ip_project.id}"
 }
 
 resource "cherryservers_ip" "test_ip_ip" {
   project_id = "${cherryservers_project.test_ip_project.id}"
-  region = "eu_nord_1"
+  region = "LT-Siauliai"
   target_hostname = "${cherryservers_server.test_ip_server.hostname}"
   a_record = "%s"
   ptr_record = "test"

--- a/internal/provider/server_data_source.go
+++ b/internal/provider/server_data_source.go
@@ -97,7 +97,7 @@ func (d *serverDataSource) Schema(ctx context.Context, req datasource.SchemaRequ
 				Optional:    true,
 			},
 			"region": schema.StringAttribute{
-				Description: "Slug of the region. Example: eu_nord_1 [See List Regions](https://api.cherryservers.com/doc/#tag/Regions/operation/get-regions).",
+				Description: "Slug of the region. Example: LT-Siauliai [See List Regions](https://api.cherryservers.com/doc/#tag/Regions/operation/get-regions).",
 				Computed:    true,
 			},
 			"name": schema.StringAttribute{

--- a/internal/provider/server_data_source_test.go
+++ b/internal/provider/server_data_source_test.go
@@ -65,7 +65,7 @@ resource "cherryservers_project" "test_server_project" {
 
 resource "cherryservers_server" "test_server_server" {
   plan = "B1-1-1gb-20s-shared"
-  region = "eu_nord_1"
+  region = "LT-Siauliai"
   project_id = "${cherryservers_project.test_server_project.id}"
 }
 

--- a/internal/provider/server_resource.go
+++ b/internal/provider/server_resource.go
@@ -158,7 +158,7 @@ func (r *serverResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				},
 			},
 			"region": schema.StringAttribute{
-				Description: "Slug of the region. Example: eu_nord_1 [See List Regions](https://api.cherryservers.com/doc/#tag/Regions/operation/get-regions).",
+				Description: "Slug of the region. Example: LT-Siauliai [See List Regions](https://api.cherryservers.com/doc/#tag/Regions/operation/get-regions).",
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),

--- a/internal/provider/server_resource_test.go
+++ b/internal/provider/server_resource_test.go
@@ -16,7 +16,7 @@ func TestAccServerResource_basic(t *testing.T) {
 	serverResourceName := "terraform_test_server_" + acctest.RandString(5)
 	projectName := testProjectNamePrefix + acctest.RandString(5)
 	testPlan := "B1-1-1gb-20s-shared"
-	testRegion := "eu_nord_1"
+	testRegion := "LT-Siauliai"
 	teamID := os.Getenv("CHERRY_TEST_TEAM_ID")
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -210,11 +210,11 @@ resource "cherryservers_ssh_key" "test_server_ssh_key" {
 
 resource "cherryservers_ip" "test_server_ip" {
   project_id = "${cherryservers_project.test_server_project.id}"
-  region = "eu_nord_1"
+  region = "LT-Siauliai"
 }
 
 resource "cherryservers_server" "test_server_server" {
-  region = "eu_nord_1"
+  region = "LT-Siauliai"
   plan = "B1-1-1gb-20s-shared"
   project_id = "${cherryservers_project.test_server_project.id}"
   name = "test"
@@ -247,11 +247,11 @@ resource "cherryservers_ssh_key" "test_server_ssh_key" {
 
 resource "cherryservers_ip" "test_server_ip" {
   project_id = "${cherryservers_project.test_server_project.id}"
-  region = "eu_nord_1"
+  region = "LT-Siauliai"
 }
 
 resource "cherryservers_server" "test_server_server" {
-  region = "eu_nord_1"
+  region = "LT-Siauliai"
   plan = "B1-1-1gb-20s-shared"
   project_id = "${cherryservers_project.test_server_project.id}"
   name = "test-reinstall"


### PR DESCRIPTION
Stop using deprecated API slug values in docs and tests.