### PR TITLE
Drop tf 1.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,9 +56,9 @@ jobs:
           - tool: opentofu
             version: v1.9.x
           - tool: terraform
-            version: v1.10.x
-          - tool: terraform
             version: v1.11.x
+          - tool: terraform
+            version: v1.12.x
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@
 
 ## Requirements
 
-- [Terraform](https://developer.hashicorp.com/terraform/downloads) >= 1.10 or compatible [OpenTofu](https://opentofu.org/docs/intro/install/) version.
+- Any non-ancient [Terraform](https://developer.hashicorp.com/terraform/downloads)
+  or [OpenTofu](https://opentofu.org/docs/intro/install/) version should work. We run our tests on the last two major
+  Terraform releases and the last major OpenTofu release.
 - [Go](https://golang.org/doc/install) >= 1.23 (to build the provider plugin)
 
 ## Building The Provider


### PR DESCRIPTION
Drop support for Terraform 1.10 in CI tests. Clarify that older versions of Terraform/OpenTofu are still likely to work.