### PR TITLE
ci: update opentofu/terraform version test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,11 +54,11 @@ jobs:
       matrix:
         include:
           - tool: opentofu
-            version: v1.9.x
+            version: v1.10.x
           - tool: terraform
-            version: v1.11.x
+            version: v1.13.x
           - tool: terraform
-            version: v1.12.x
+            version: v1.14.x
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Drop older OpenTofu/Terraform versions in CI testing, and test for new ones.