### PR TITLE
fix: generate password in cryptographically secure way

### DIFF
--- a/internal/provider/helpers.go
+++ b/internal/provider/helpers.go
@@ -1,12 +1,14 @@
 package provider
 
 import (
+	"crypto/rand"
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"github.com/cherryservers/cherrygo/v3"
-	"math/rand"
+	"math/big"
 	"strings"
+
+	"github.com/cherryservers/cherrygo/v3"
 )
 
 // is404Error returns true if err is an HTTP 404 error.
@@ -58,21 +60,37 @@ func normalizeServerImage(server *cherrygo.Server, client *cherrygo.Client) erro
 }
 
 // generatePassword is used to generate a password that matches CherryServers password constraints.
-func generatePassword() string {
+func generatePassword() (string, error) {
 	const (
-		lowercaseLetters = "abcdefghijklmnopqrstuvwxyz"
-		uppercaseLetters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-		digits           = "0123456789"
-		all              = lowercaseLetters + uppercaseLetters + digits
+		lowercase = "abcdefghijklmnopqrstuvwxyz"
+		uppercase = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+		digits    = "0123456789"
+		all       = lowercase + uppercase + digits
+		length    = 20
 	)
+	password := make([]byte, length)
 
-	password := make([]byte, 16)
-	password[0] = lowercaseLetters[rand.Intn(len(lowercaseLetters))]
-	password[1] = uppercaseLetters[rand.Intn(len(uppercaseLetters))]
-	password[2] = digits[rand.Intn(len(digits))]
-	for i := 3; i < 16; i++ {
-		password[i] = all[rand.Intn(len(all))]
+	var charset string
+	for i := range length {
+		switch i {
+		case 0:
+			// Ensure there is at least one lower-case alphabetical character.
+			charset = lowercase
+		case 1:
+			// Ensure there is at least one upper-case alphabetical
+			// character that is not first.
+			charset = uppercase
+		case 2:
+			// Ensure there is at least one digit that is not last.
+			charset = digits
+		default:
+			charset = all
+		}
+		idx, err := rand.Int(rand.Reader, big.NewInt(int64(len(charset))))
+		if err != nil {
+			return "", err
+		}
+		password[i] = charset[idx.Int64()]
 	}
-
-	return string(password)
+	return string(password), nil
 }

--- a/internal/provider/helpers_test.go
+++ b/internal/provider/helpers_test.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"regexp"
 	"strconv"
+	"testing"
 
 	"github.com/cherryservers/cherrygo/v3"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -55,4 +56,57 @@ func findPlanIndex(id int, client *cherrygo.Client) (int, error) {
 	}
 
 	return 0, errors.New("plan index not found")
+}
+
+func TestGeneratePassword(t *testing.T) {
+	const (
+		cases  = 1000
+		length = 20
+	)
+	passwords := make(map[string]struct{}, cases)
+
+	for range cases {
+		p, err := generatePassword()
+		if err != nil {
+			t.Fatal("failed to generate password")
+		}
+
+		if len(p) != length {
+			t.Fatalf("password %q length %d, want %d", p, len(p), length)
+		}
+
+		if _, ok := passwords[p]; ok {
+			t.Errorf("password %q repeated", p)
+		}
+		passwords[p] = struct{}{}
+
+		hasLowercase := false
+		hasNonFirstUppercase := false
+		hasNonLastDigit := false
+		allAlphaNums := true
+
+		for i, c := range p {
+			switch {
+			case c >= 'a' && c <= 'z':
+				hasLowercase = true
+			case c >= 'A' && c <= 'Z':
+				if i != 0 {
+					hasNonFirstUppercase = true
+				}
+			case c >= '0' && c <= '9':
+				if i != len(p)-1 {
+					hasNonLastDigit = true
+				}
+			default:
+				allAlphaNums = false
+			}
+		}
+
+		if !hasLowercase || !hasNonFirstUppercase || !hasNonLastDigit || !allAlphaNums {
+			t.Errorf("password %q didn't fit all constraints: hasLowercase: %t, "+
+				"hasNonFirstUppercase: %t, hasNonLastDigit: %t, allAlphaNums: %t", p,
+				hasLowercase, hasNonFirstUppercase, hasNonLastDigit, allAlphaNums)
+		}
+
+	}
 }

--- a/internal/provider/server_resource.go
+++ b/internal/provider/server_resource.go
@@ -682,7 +682,13 @@ func (r *serverResource) Update(ctx context.Context, req resource.UpdateRequest,
 }
 
 func (r *serverResource) reinstall(ctx context.Context, plan serverResourceModel, resp *resource.UpdateResponse) {
-	password := generatePassword()
+	password, err := generatePassword()
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"unable to generate password", err.Error(),
+		)
+		return
+	}
 	serverID, _ := strconv.Atoi(plan.Id.ValueString())
 
 	requestReinstall := &cherrygo.ReinstallServerFields{


### PR DESCRIPTION
Using math/rand is not considered safe in a security sensitive context. Generate passwords with crypto/rand instead.