### PR TITLE
Ensure tests are run with sweeping enabled in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,10 +88,12 @@ jobs:
 
       - run: go mod download
       - env:
-          TF_ACC: "1"
           CHERRY_AUTH_KEY: ${{secrets.CHERRY_AUTH_KEY}}
           CHERRY_TEST_TEAM_ID: ${{secrets.CHERRY_TEST_TEAM_ID}}
-        run: go test -v ./internal/provider/ -coverprofile=coverage.txt -parallel=1 -timeout=90m
+          # The sweep flag requires a region for each client, but we don't use that,
+          # so just pass "no-region".
+          TESTARGS: "-coverprofile=coverage.txt -parallel=1 -args -sweep='no-region'"
+        run: make testacc
 
       - uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
         with:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -2,5 +2,6 @@ default: testacc
 
 # Run acceptance tests
 .PHONY: testacc
+
 testacc:
-	TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 120m
+	TF_AC=1 go test ./... -v -timeout 60m $(TESTARGS)


### PR DESCRIPTION
The `sweep` flag is required to enable test sweeping, and while in most cases the tests clean up after themselves, since the destruction step is an implicit part of the acceptance test case, resources can still leak in some unexpected failure/error conditions.