### PR TITLE
Remove single parallel test constraint in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,7 +92,7 @@ jobs:
           CHERRY_TEST_TEAM_ID: ${{secrets.CHERRY_TEST_TEAM_ID}}
           # The sweep flag requires a region for each client, but we don't use that,
           # so just pass "no-region".
-          TESTARGS: "-coverprofile=coverage.txt -parallel=1 -args -sweep='no-region'"
+          TESTARGS: "-coverprofile=coverage.txt -args -sweep='no-region'"
         run: make testacc
 
       - uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,10 +88,12 @@ jobs:
 
       - run: go mod download
       - env:
-          TF_ACC: "1"
           CHERRY_AUTH_KEY: ${{secrets.CHERRY_AUTH_KEY}}
           CHERRY_TEST_TEAM_ID: ${{secrets.CHERRY_TEST_TEAM_ID}}
-        run: go test -v ./internal/provider/ -coverprofile=coverage.txt -parallel=1 -timeout=90m
+          # The sweep flag requires a region for each client, but we don't use that,
+          # so just pass "no-region".
+          TESTARGS: "-coverprofile=coverage.txt -parallel=1 -args -sweep='no-region'"
+        run: make testacc
 
       - uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
         with:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -2,5 +2,6 @@ default: testacc
 
 # Run acceptance tests
 .PHONY: testacc
+
 testacc:
-	TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 120m
+	TF_AC=1 go test ./... -v -timeout 60m $(TESTARGS)


### PR DESCRIPTION
This was added due to flakiness concerns, stemming from API constraints, but, at least judging from local testing, the situation seems to have improved, so it's worth trying to increase parallelism for faster tests.

With the constraint removed, parallelism will default to the number of cores on the runner, which should be four, currently.

Based on https://github.com/cherryservers/terraform-provider-cherryservers/pull/106, to avoid conflicts.