### PR TITLE
Add UseStateForUnknown plan modifier to server pricing

### DIFF
--- a/internal/provider/server_resource.go
+++ b/internal/provider/server_resource.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -386,6 +387,9 @@ func (r *serverResource) Schema(ctx context.Context, req resource.SchemaRequest,
 						Computed:    true,
 						Description: "Pricing currency.",
 					},
+				},
+				PlanModifiers: []planmodifier.Object{
+					objectplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"allow_reinstall": schema.BoolAttribute{


### PR DESCRIPTION
Although it's technically possible for the pricing to change, such cases should be rare enough that it's not worth the trade-off of reduced plan clarity, since updates and reinstalls have no impact on pricing.