### PR TITLE
Add 7 day dependabot cooldown and remove GitHub Actions allow-list restriction

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,18 @@
-# See GitHub's documentation for more information on this file:
-# https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
 version: 2
 updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
+      include:
+        - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
-    # TODO: Dependabot only updates hashicorp GHAs in the template repository, the following lines can be removed for consumers of this template
-    allow:
-      - dependency-name: "hashicorp/*"
+    cooldown:
+      default-days: 7
+      include:
+        - "*"


### PR DESCRIPTION
An extra precaution against supply chain attacks.

Also removes the `allow: hashicorp/*` restriction on the `github-actions` ecosystem block. Dependabot will now track updates for all GitHub Actions used in workflows, not just HashiCorp's. The removed TODO noted this restriction only applied to the template repository and could be dropped for consumers of the template.