### PR TITLE
fix: match module path with repo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module terraform-provider-cherryservers
+module github.com/cherryservers/terraform-provider-cherryservers
 
 go 1.25.8
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -9,13 +9,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
+	"github.com/cherryservers/terraform-provider-cherryservers/internal/provider/datasourcebase"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/function"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"terraform-provider-cherryservers/internal/provider/datasourcebase"
 )
 
 // Ensure CherryServersProvider satisfies various provider interfaces.

--- a/main.go
+++ b/main.go
@@ -8,8 +8,8 @@ import (
 	"flag"
 	"log"
 
+	"github.com/cherryservers/terraform-provider-cherryservers/internal/provider"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	"terraform-provider-cherryservers/internal/provider"
 )
 
 // Run "go generate" to format example terraform files and generate the docs for the registry/website
@@ -22,14 +22,12 @@ import (
 // can be customized.
 //go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs generate -provider-name cherryservers
 
-var (
-	// these will be set by the goreleaser configuration
-	// to appropriate values for the compiled binary.
-	version string = "dev"
+// these will be set by the goreleaser configuration
+// to appropriate values for the compiled binary.
+var version string = "dev"
 
-	// goreleaser can pass other information to the main package, such as the specific commit
-	// https://goreleaser.com/cookbooks/using-main.version/
-)
+// goreleaser can pass other information to the main package, such as the specific commit
+// https://goreleaser.com/cookbooks/using-main.version/
 
 func main() {
 	var debug bool
@@ -43,7 +41,6 @@ func main() {
 	}
 
 	err := providerserver.Serve(context.Background(), provider.New(version), opts)
-
 	if err != nil {
 		log.Fatal(err.Error())
 	}


### PR DESCRIPTION
This makes it so the module can be imported without the need for additional replacement directives.