### PR TITLE
ci(fix): separate acceptance tests and sweeping jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,11 +68,25 @@ jobs:
       - env:
           CHERRY_API_KEY: ${{secrets.CHERRY_AUTH_KEY}}
           CHERRY_TEST_TEAM_ID: ${{secrets.CHERRY_TEST_TEAM_ID}}
-          # The sweep flag requires a region for each client, but we don't use that,
-          # so just pass "no-region".
-          TESTARGS: "-coverprofile=coverage.txt -args -sweep='no-region'"
+          TESTARGS: "-coverprofile=coverage.txt"
         run: make testacc
 
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  sweep:
+    needs: test
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: "go.mod"
+          cache: true
+      - run: go mod download
+      - env:
+          CHERRY_API_KEY: ${{secrets.CHERRY_AUTH_KEY}}
+          CHERRY_TEST_TEAM_ID: ${{secrets.CHERRY_TEST_TEAM_ID}}
+        run: make sweep

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,7 +1,9 @@
 default: testacc
 
-# Run acceptance tests
-.PHONY: testacc
+.PHONY: testacc sweep
 
 testacc:
 	TF_ACC=1 go test ./... -v -timeout 60m $(TESTARGS)
+
+sweep:
+	TF_ACC=1 go test ./internal/provider -args -sweep='no-region'


### PR DESCRIPTION
Runnning tests with the -sweep flag doesn't actually run the tests, only the sweepers. The proper way to do it is to have separate targets and jobs for testing and sweeping.