### PR TITLE
test(fix): use randomized project names for ipxe tests

### DIFF
--- a/internal/provider/server_resource_test.go
+++ b/internal/provider/server_resource_test.go
@@ -139,7 +139,7 @@ func TestAccServerIPXE(t *testing.T) {
 	}
 
 	const resourceName = "cherryservers_server.ipxe_test"
-	project := testProjectNamePrefix + "ipxe"
+	project := testProjectNamePrefix + acctest.RandString(5)
 	plan, region := ipxePlanRegion(t, testCherryGoClient, testTeam)
 	ipxeCreate := ipxeScript(t, filepath.Join("testdata", "ubuntu.ipxe"))
 	ipxeReinstall := ipxeScript(t, filepath.Join("testdata", "alma.ipxe"))
@@ -177,7 +177,7 @@ func TestAccServerIPXE(t *testing.T) {
 			{
 				// Succeed when valid iPXE script is provided and image is left
 				// for the provider to set.
-				Config: ipxeConfig(region, plan, ipxeCreate, testTeam, false, false),
+				Config: ipxeConfig(project, region, plan, ipxeCreate, testTeam, false, false),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectKnownValue(
@@ -196,17 +196,17 @@ func TestAccServerIPXE(t *testing.T) {
 			},
 			{
 				// Fail when updating iPXE script, but allow_reinstall is not enabled.
-				Config:      ipxeConfig(region, plan, ipxeReinstall, testTeam, false, false),
+				Config:      ipxeConfig(project, region, plan, ipxeReinstall, testTeam, false, false),
 				ExpectError: regexp.MustCompile("allow_reinstall attribute not set"),
 			},
 			{
 				// Fail when updating persist_ipxe, but allow_reinstall is not enabled.
-				Config:      ipxeConfig(region, plan, ipxeReinstall, testTeam, false, true),
+				Config:      ipxeConfig(project, region, plan, ipxeReinstall, testTeam, false, true),
 				ExpectError: regexp.MustCompile("allow_reinstall attribute not set"),
 			},
 			{
 				// Succeed when reinstalling with a new iPXE script and persist_ipxe.
-				Config: ipxeConfig(region, plan, ipxeReinstall, testTeam, true, true),
+				Config: ipxeConfig(project, region, plan, ipxeReinstall, testTeam, true, true),
 			},
 			{
 				// Fail when a standard image is configured along with an iPXE script.
@@ -456,7 +456,7 @@ resource "cherryservers_server" "test_server_server" {
 `, projectName, teamID, sshKeyLabel, sshKeyPublicKey)
 }
 
-func ipxeConfig(region, plan, ipxe string, team int, allowReinstall, persistIPXE bool) string {
+func ipxeConfig(project, region, plan, ipxe string, team int, allowReinstall, persistIPXE bool) string {
 	return fmt.Sprintf(`
 resource "cherryservers_project" "test_server_project" {
   name = "%s"
@@ -472,7 +472,7 @@ resource "cherryservers_server" "ipxe_test" {
   allow_reinstall = %t
   configure_ipv6 = true
 }
-`, testProjectNamePrefix+"ipxe", team, region, plan, ipxe, persistIPXE, allowReinstall)
+`, project, team, region, plan, ipxe, persistIPXE, allowReinstall)
 }
 
 func ipxeOnlyImageConfig(projectName, region, plan, image string, team int, allowReinstall bool) string {


### PR DESCRIPTION
Otherwise we hit duplicate name errors in CI.