### PR TITLE
Prepare for pulumi provider bridging

### DIFF
--- a/docs/data-sources/ip.md
+++ b/docs/data-sources/ip.md
@@ -20,7 +20,7 @@ data "cherryservers_ip" "my_ip" {
 
 # Get IP address info by address and project ID.
 data "cherryservers_ip" "by_address" {
-  ip_address = "0.0.0.0"
+  address    = "0.0.0.0"
   project_id = "123456"
 }
 ```

--- a/docs/resources/ip.md
+++ b/docs/resources/ip.md
@@ -20,7 +20,7 @@ resource "cherryservers_ip" "floating-1" {
 }
 
 # Create a new floating IP address with optional parameters
-resource "cherryservers_ip" "floating-1" {
+resource "cherryservers_ip" "floating-2" {
   project_id      = 123
   region          = "LT-Siauliai"
   target_hostname = "gentle-turtle"

--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -14,14 +14,14 @@ Provides a Cherry Servers server resource. This can be used to create, read, mod
 
 ```terraform
 #Create a new server:
-resource "cherryservers_server" "server" {
+resource "cherryservers_server" "server-1" {
   plan       = "B1-1-1gb-20s-shared"
   project_id = 123456
   region     = "LT-Siauliai"
 }
 
 #Create a new server with options:
-resource "cherryservers_server" "server" {
+resource "cherryservers_server" "server-2" {
   plan                   = "B1-1-1gb-20s-shared"
   hostname               = "sharing-wallaby"
   project_id             = 123456

--- a/examples/data-sources/cherryservers_ip/data-source.tf
+++ b/examples/data-sources/cherryservers_ip/data-source.tf
@@ -5,6 +5,6 @@ data "cherryservers_ip" "my_ip" {
 
 # Get IP address info by address and project ID.
 data "cherryservers_ip" "by_address" {
-  ip_address = "0.0.0.0"
+  address    = "0.0.0.0"
   project_id = "123456"
 }

--- a/examples/resources/cherryservers_ip/resource.tf
+++ b/examples/resources/cherryservers_ip/resource.tf
@@ -5,7 +5,7 @@ resource "cherryservers_ip" "floating-1" {
 }
 
 # Create a new floating IP address with optional parameters
-resource "cherryservers_ip" "floating-1" {
+resource "cherryservers_ip" "floating-2" {
   project_id      = 123
   region          = "LT-Siauliai"
   target_hostname = "gentle-turtle"

--- a/examples/resources/cherryservers_server/resource.tf
+++ b/examples/resources/cherryservers_server/resource.tf
@@ -1,12 +1,12 @@
 #Create a new server:
-resource "cherryservers_server" "server" {
+resource "cherryservers_server" "server-1" {
   plan       = "B1-1-1gb-20s-shared"
   project_id = 123456
   region     = "LT-Siauliai"
 }
 
 #Create a new server with options:
-resource "cherryservers_server" "server" {
+resource "cherryservers_server" "server-2" {
   plan                   = "B1-1-1gb-20s-shared"
   hostname               = "sharing-wallaby"
   project_id             = 123456

--- a/pulumi/provider.go
+++ b/pulumi/provider.go
@@ -1,0 +1,12 @@
+// Package pulumi exposes provider internals for pulumi bridging.
+package pulumi
+
+import (
+	"github.com/cherryservers/terraform-provider-cherryservers/internal/provider"
+	tfprovider "github.com/hashicorp/terraform-plugin-framework/provider"
+)
+
+// New exports the provider factory for the pulumi bridge.
+func New(version string) func() tfprovider.Provider {
+	return provider.New(version)
+}


### PR DESCRIPTION
This requires exposing the provider factory, which used to be internal and some documentation fixes.