### PR TITLE
ci: bump terraform test versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,9 +34,9 @@ jobs:
           - tool: opentofu
             version: v1.12.x
           - tool: terraform
-            version: v1.14.x
-          - tool: terraform
             version: v1.15.x
+          - tool: terraform
+            version: v1.16.x
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
Tests succeed: https://github.com/cherryservers/terraform-provider-cherryservers/actions/runs/33868070183.