### PR TITLE
Add server plan modifier that checks if `allow_reinstal` is enabled

### DIFF
--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -62,12 +62,12 @@ resource "cherryservers_server" "server" {
 - `discount_code` (String) Server discount code.
 - `extra_ip_addresses_ids` (Set of String) Set of the IP address IDs to be embedded into the server.
 - `hostname` (String) Hostname of the server.
-- `image` (String) Slug of the server operating system. Updating this attribute requires a server re-install. If iPXE is used, this must be set to `custom_ipxe_install` or left unconfigured, in which case the provider will set the correct image. Updating this attribute requires a server re-install.
+- `image` (String) Slug of the server operating system. If iPXE is used, this must be set to `custom_ipxe_install` or left unconfigured, in which case the provider will set the correct image. Updating this attribute requires a server re-install.
 - `ip_addresses_ids` (Set of String, Deprecated) **Deprecated**.Set of the IP address IDs to be embedded into the server.
 - `ipxe` (String, Sensitive) Base64-encoded iPXE template blob. The decoded content must start with `#!ipxe`. Updating this attribute requires a server re-install. Note that not all server plans support iPXE, use the plan/plans data sources to check supported OS images.
 - `name` (String) Name of the server.
 - `os_partition_size` (Number) OS partition size in GB. Updating this attribute requires a server re-install.
-- `persist_ipxe` (Boolean) Enable persisting the universal iPXE image between server boots. See https://www.cherryservers.com/knowledge/docs/compute/configuration-management/ipxe#how-ipxe-works-with-cherry-servers.
+- `persist_ipxe` (Boolean) Enable persisting the universal iPXE image between server boots. See https://www.cherryservers.com/knowledge/docs/compute/configuration-management/ipxe#how-ipxe-works-with-cherry-servers. Updating this attribute requires a server re-install.
 - `spot_instance` (Boolean) If True, provisions the server as a spot instance.
 - `ssh_key_ids` (Set of String) Set of the SSH key IDs allowed to SSH to the server. Updating this attribute requires a server re-install.
 - `tags` (Map of String) Key/value metadata for server tagging.

--- a/internal/provider/server_resource.go
+++ b/internal/provider/server_resource.go
@@ -182,13 +182,7 @@ func (r *serverResource) Metadata(ctx context.Context, req resource.MetadataRequ
 }
 
 func (r *serverResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
-	const (
-		warnReinstallSummary = "Server re-install required."
-		warnReinstallDetail  = "You are updating attributes that require a server re-install." +
-			" This will wipe all of your data and may take awhile." +
-			" Requires `allow_reinstall to be set to `true`."
-	)
-
+	const requiresReinstall = "Updating this attribute requires a server re-install."
 	resp.Schema = schema.Schema{
 		// This description is used by the documentation generator and the language server.
 		Description: "Provides a Cherry Servers server resource. This can be used to create, read, modify, and delete servers on your Cherry Servers account.",
@@ -233,13 +227,10 @@ func (r *serverResource) Schema(ctx context.Context, req resource.SchemaRequest,
 			},
 			"ipxe": schema.StringAttribute{
 				Description: "Base64-encoded iPXE template blob. The decoded content must start with `#!ipxe`. " +
-					"Updating this attribute requires a server re-install. " +
-					"Note that not all server plans support iPXE, use the plan/plans data sources " +
+					requiresReinstall +
+					" Note that not all server plans support iPXE, use the plan/plans data sources " +
 					"to check supported OS images.",
 				Optional: true,
-				PlanModifiers: []planmodifier.String{
-					WarnIfChangedString(warnReinstallSummary, warnReinstallDetail),
-				},
 				Validators: []validator.String{
 					stringvalidator.ConflictsWith(path.Expressions{
 						path.MatchRoot("ssh_key_ids"),
@@ -250,38 +241,32 @@ func (r *serverResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				Sensitive: true,
 			},
 			"persist_ipxe": schema.BoolAttribute{
-				Description: "Enable persisting the universal iPXE image between server boots. See https://www.cherryservers.com/knowledge/docs/compute/configuration-management/ipxe#how-ipxe-works-with-cherry-servers.",
-				Optional:    true,
+				Description: "Enable persisting the universal iPXE image between server boots. See https://www.cherryservers.com/knowledge/docs/compute/configuration-management/ipxe#how-ipxe-works-with-cherry-servers. " +
+					requiresReinstall,
+				Optional: true,
 				Validators: []validator.Bool{
 					boolvalidator.AlsoRequires(path.MatchRoot("ipxe")),
-				},
-				PlanModifiers: []planmodifier.Bool{
-					WarnIfChangedBool(warnReinstallSummary, warnReinstallDetail),
 				},
 			},
 			"image": schema.StringAttribute{
 				Description: "Slug of the server operating system. " +
-					"Updating this attribute requires a server re-install. " +
 					"If iPXE is used, this must be set to `" + ipxeImage +
 					"` or left unconfigured, in which case the provider will set the " +
-					"correct image. " +
-					"Updating this attribute requires a server re-install.",
+					"correct image. " + requiresReinstall,
 				Optional: true,
 				Computed: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
-					WarnIfChangedString(warnReinstallSummary, warnReinstallDetail),
 				},
 			},
 			"ssh_key_ids": schema.SetAttribute{
 				Description: "Set of the SSH key IDs allowed to SSH to the server. " +
-					"Updating this attribute requires a server re-install.",
+					requiresReinstall,
 				Optional:    true,
 				Computed:    true,
 				ElementType: types.StringType,
 				PlanModifiers: []planmodifier.Set{
 					setplanmodifier.UseStateForUnknown(),
-					WarnIfChangedSet(warnReinstallSummary, warnReinstallDetail),
 				},
 			},
 			"extra_ip_addresses_ids": schema.SetAttribute{
@@ -315,11 +300,8 @@ func (r *serverResource) Schema(ctx context.Context, req resource.SchemaRequest,
 			},
 			"user_data": schema.StringAttribute{
 				Description: "Base64 encoded user-data blob. It should be a bash or cloud-config script. " +
-					"Updating this attribute requires a server re-install.",
-				Optional: true,
-				PlanModifiers: []planmodifier.String{
-					WarnIfChangedString(warnReinstallSummary, warnReinstallDetail),
-				},
+					requiresReinstall,
+				Optional:  true,
 				Sensitive: true,
 			},
 			"tags": schema.MapAttribute{
@@ -343,12 +325,8 @@ func (r *serverResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				},
 			},
 			"os_partition_size": schema.Int64Attribute{
-				Description: "OS partition size in GB. " +
-					"Updating this attribute requires a server re-install.",
-				Optional: true,
-				PlanModifiers: []planmodifier.Int64{
-					WarnIfChangedInt64(warnReinstallSummary, warnReinstallDetail),
-				},
+				Description: "OS partition size in GB. " + requiresReinstall,
+				Optional:    true,
 			},
 			"power_state": schema.StringAttribute{
 				Description: "The power state of the server, such as 'Powered off' or 'Powered on'.",

--- a/internal/provider/server_resource.go
+++ b/internal/provider/server_resource.go
@@ -576,6 +576,10 @@ func (r *serverResource) ModifyPlan(ctx context.Context, req resource.ModifyPlan
 	}
 
 	if requiresReinstall(plan, state) {
+		if !plan.AllowReinstall.ValueBool() {
+			appendReinstallNotAllowedErrors(&resp.Diagnostics, plan, state)
+			return
+		}
 		resp.Diagnostics.Append(r.modifyReinstall(ctx, &plan, state, config)...)
 		if resp.Diagnostics.HasError() {
 			return
@@ -1122,4 +1126,33 @@ func requiresReinstall(plan, state serverResourceModel) bool {
 		return true
 	}
 	return false
+}
+
+func appendReinstallNotAllowedErrors(d *diag.Diagnostics, plan, state serverResourceModel) {
+	var errs diag.Diagnostics
+
+	const (
+		summary = "Re-installation not allowed."
+		detail  = "Updating `%s` requires `allow_reinstall` to be enabled."
+	)
+	if !plan.Image.Equal(state.Image) {
+		d.AddAttributeError(path.Root("image"), summary, fmt.Sprintf(detail, "image"))
+	}
+	if !plan.OSPartitionSize.Equal(state.OSPartitionSize) {
+		d.AddAttributeError(path.Root("os_partition_size"), summary, fmt.Sprintf(detail, "os_partition_size"))
+	}
+	if !plan.SSHKeyIds.Equal(state.SSHKeyIds) {
+		d.AddAttributeError(path.Root("ssh_key_ids"), summary, fmt.Sprintf(detail, "ssh_key_ids"))
+	}
+	if !plan.UserData.Equal(state.UserData) {
+		d.AddAttributeError(path.Root("user_data"), summary, fmt.Sprintf(detail, "user_data"))
+	}
+	if !plan.IPXE.Equal(state.IPXE) {
+		d.AddAttributeError(path.Root("ipxe"), summary, fmt.Sprintf(detail, "ipxe"))
+	}
+	if !plan.PersistIPXE.Equal(state.PersistIPXE) {
+		d.AddAttributeError(path.Root("persist_ipxe"), summary, fmt.Sprintf(detail, "persist_ipxe"))
+	}
+
+	d.Append(errs...)
 }

--- a/internal/provider/server_resource.go
+++ b/internal/provider/server_resource.go
@@ -576,36 +576,49 @@ func (r *serverResource) ModifyPlan(ctx context.Context, req resource.ModifyPlan
 	}
 
 	if requiresReinstall(plan, state) {
-		// Power state can be unpredictable when re-installing.
-		plan.PowerState = types.StringUnknown()
-
-		resp.Diagnostics.Append(modifyPrivateIP(ctx, &plan)...)
+		resp.Diagnostics.Append(r.modifyReinstall(ctx, &plan, state, config)...)
 		if resp.Diagnostics.HasError() {
 			return
-		}
-
-		// Ensure we don't pass SSH keys, when reinstalling non-iPXE -> iPXE,
-		// since SSH keys use state, if unconfigured.
-		if !plan.IPXE.IsNull() && state.Image.ValueString() != ipxeImage {
-			plan.SSHKeyIds = types.SetValueMust(types.StringType, []attr.Value{})
-		}
-	}
-
-	// If we need to reinstall an iPXE server into a non-iPXE server, we may need
-	// to find a default image, if the user didn't configure one.
-	if requiresReinstall(plan, state) && plan.IPXE.IsNull() && state.Image.ValueString() == ipxeImage {
-		serverPlan := plan.Plan
-
-		if config.Image.IsNull() {
-			resp.Diagnostics.Append(r.modifyImage(ctx, serverPlan, &plan)...)
-			if resp.Diagnostics.HasError() {
-				return
-			}
 		}
 	}
 
 	diags := resp.Plan.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
+}
+
+func (r *serverResource) modifyReinstall(
+	ctx context.Context,
+	plan *serverResourceModel,
+	state, config serverResourceModel,
+) diag.Diagnostics {
+	var d diag.Diagnostics
+
+	// Power state can be unpredictable when re-installing.
+	plan.PowerState = types.StringUnknown()
+
+	// Private IP may change on reinstall.
+	d.Append(modifyPrivateIP(ctx, plan)...)
+	if d.HasError() {
+		return d
+	}
+
+	// Ensure we don't pass SSH keys, when reinstalling non-iPXE -> iPXE,
+	// since SSH keys use state, if unconfigured.
+	if !plan.IPXE.IsNull() && state.Image.ValueString() != ipxeImage {
+		plan.SSHKeyIds = types.SetValueMust(types.StringType, []attr.Value{})
+	}
+
+	// If we need to reinstall iPXE -> non-iPXE, we may need
+	// to find a default image, if the user didn't configure one.
+	if plan.IPXE.IsNull() && state.Image.ValueString() == ipxeImage {
+		serverPlan := plan.Plan
+
+		if config.Image.IsNull() {
+			d.Append(r.modifyImage(ctx, serverPlan, plan)...)
+		}
+	}
+
+	return d
 }
 
 func modifyPrivateIP(ctx context.Context, plan *serverResourceModel) diag.Diagnostics {

--- a/internal/provider/server_resource.go
+++ b/internal/provider/server_resource.go
@@ -871,12 +871,6 @@ func (r *serverResource) Update(ctx context.Context, req resource.UpdateRequest,
 	serverID, _ := strconv.Atoi(plan.Id.ValueString())
 
 	if requiresReinstall(plan, state) {
-		if !plan.AllowReinstall.ValueBool() {
-			resp.Diagnostics.AddError("allow_reinstall attribute not set",
-				"updating image, ssh_key_ids, os_partition_size, user_data or ipxe requires setting allow_reinstall to true")
-			return
-		}
-
 		r.reinstall(ctx, plan, resp)
 		if resp.Diagnostics.HasError() {
 			return


### PR DESCRIPTION
Adds server resource plan modifier that checks if `allow_reinstall` is enabled, if the plan requires re-installation. Currently, we display a warning message, when attempting to update attributes that would require re-installation. This replaces that message with an attribute error. It also trims some documentation that is, in my opinion, a bit excessive - we don't need a long-winded description about the dangers of re-installation for every attribute, a simple "Updating this attribute requires a server re-install." is sufficient.

Acceptance tests pass for stack head: https://github.com/cherryservers/terraform-provider-cherryservers/actions/runs/33870452244.

Fixes https://github.com/cherryservers/terraform-provider-cherryservers/issues/137.