### PR TITLE
Add server plan modification unit tests

### DIFF
--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -62,12 +62,12 @@ resource "cherryservers_server" "server" {
 - `discount_code` (String) Server discount code.
 - `extra_ip_addresses_ids` (Set of String) Set of the IP address IDs to be embedded into the server.
 - `hostname` (String) Hostname of the server.
-- `image` (String) Slug of the server operating system. Updating this attribute requires a server re-install. If iPXE is used, this must be set to `custom_ipxe_install` or left unconfigured, in which case the provider will set the correct image. Updating this attribute requires a server re-install.
+- `image` (String) Slug of the server operating system. If iPXE is used, this must be set to `custom_ipxe_install` or left unconfigured, in which case the provider will set the correct image. Updating this attribute requires a server re-install.
 - `ip_addresses_ids` (Set of String, Deprecated) **Deprecated**.Set of the IP address IDs to be embedded into the server.
 - `ipxe` (String, Sensitive) Base64-encoded iPXE template blob. The decoded content must start with `#!ipxe`. Updating this attribute requires a server re-install. Note that not all server plans support iPXE, use the plan/plans data sources to check supported OS images.
 - `name` (String) Name of the server.
 - `os_partition_size` (Number) OS partition size in GB. Updating this attribute requires a server re-install.
-- `persist_ipxe` (Boolean) Enable persisting the universal iPXE image between server boots. See https://www.cherryservers.com/knowledge/docs/compute/configuration-management/ipxe#how-ipxe-works-with-cherry-servers.
+- `persist_ipxe` (Boolean) Enable persisting the universal iPXE image between server boots. See https://www.cherryservers.com/knowledge/docs/compute/configuration-management/ipxe#how-ipxe-works-with-cherry-servers. Updating this attribute requires a server re-install.
 - `spot_instance` (Boolean) If True, provisions the server as a spot instance.
 - `ssh_key_ids` (Set of String) Set of the SSH key IDs allowed to SSH to the server. Updating this attribute requires a server re-install.
 - `tags` (Map of String) Key/value metadata for server tagging.

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.31.0
 	github.com/hashicorp/terraform-plugin-log v0.11.0
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
+	github.com/stretchr/testify v1.12.1
 )
 
 require (
@@ -72,6 +73,7 @@ require (
 	github.com/yuin/goldmark-meta v1.1.0 // indirect
 	github.com/zclconf/go-cty v1.18.1 // indirect
 	go.abhg.dev/goldmark/frontmatter v0.2.0 // indirect
+	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b // indirect
 	golang.org/x/mod v0.35.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -169,8 +169,6 @@ github.com/oklog/run v1.2.0/go.mod h1:mgDbKRSwPhJfesJ4PntqFUbKQRZ50NgmZTSPlFA0YF
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=
 github.com/pjbgf/sha1cd v0.3.2/go.mod h1:zQWigSxVmsHEZow5qaLtPYxpcKMMQpa09ixqBxuCS6A=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
-github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXqo=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
@@ -189,8 +187,8 @@ github.com/spf13/cast v1.9.2/go.mod h1:jNfB8QC9IA6ZuY2ZjDp0KtFO2LZZlg4S/7bzP6qqe
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
-github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWDWE=
+github.com/stretchr/testify v1.12.1/go.mod h1:MDEgiDPPsNp5cuIrHPPCyornHKgEVbtFUmoNlxoYthg=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
@@ -223,6 +221,8 @@ go.opentelemetry.io/otel/sdk/metric v1.44.0 h1:3LlKgI+VjbVsjNRFZJZAJ30WjXC5VkNRk
 go.opentelemetry.io/otel/sdk/metric v1.44.0/go.mod h1:5B5pMARnXxKhltooO4xUuCBorl65a4EpnTalObqOigA=
 go.opentelemetry.io/otel/trace v1.44.0 h1:jxF5CsGYCe74MCRx2X4g7WsY/VBKRqqpNvXlX/6gtIk=
 go.opentelemetry.io/otel/trace v1.44.0/go.mod h1:oLl1jrMQAVo6v3GAggN+1VH9VIz9iUSvW53sW1Q8PIE=
+go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=
+go.yaml.in/yaml/v3 v3.0.5/go.mod h1:HVTZu1O7/Vkt2N+BFy8Zza+lnLsABggaTM2ZpNIGuKg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=

--- a/internal/provider/plan_modifiers.go
+++ b/internal/provider/plan_modifiers.go
@@ -2,10 +2,15 @@ package provider
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
+	"github.com/cherryservers/cherrygo/v4"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 var _ planmodifier.String = useStateIfNoConfigurationChangesModifier{}
@@ -195,4 +200,125 @@ func (d warnIfChangedModifier) PlanModifyBool(ctx context.Context, req planmodif
 	}
 
 	resp.Diagnostics.AddAttributeWarning(req.Path, d.warningSummary, d.warningDetail)
+}
+
+type imgLister interface {
+	List(ctx context.Context, serverPlan string, opts *cherrygo.GetOptions) ([]cherrygo.Image, *cherrygo.Response, error)
+}
+
+type serverReinstallModifier struct {
+	plan          *serverResourceModel
+	state, config serverResourceModel
+	lister        imgLister
+}
+
+// modify modifies the plan for server re-installation.
+func (m *serverReinstallModifier) modify(ctx context.Context) diag.Diagnostics {
+	var d diag.Diagnostics
+
+	// Power state can be unpredictable when re-installing.
+	m.plan.PowerState = types.StringUnknown()
+
+	// Private IP may change on reinstall.
+	d.Append(m.modifyPrivateIP(ctx)...)
+	if d.HasError() {
+		return d
+	}
+
+	// Ensure we don't pass SSH keys, when reinstalling non-iPXE -> iPXE,
+	// since SSH keys use state, if unconfigured.
+	if !m.plan.IPXE.IsNull() && m.state.Image.ValueString() != ipxeImage {
+		m.plan.SSHKeyIds = types.SetValueMust(types.StringType, []attr.Value{})
+	}
+
+	// If we need to reinstall iPXE -> non-iPXE, we may need
+	// to find a default image, if the user didn't configure one.
+	if m.plan.IPXE.IsNull() && m.state.Image.ValueString() == ipxeImage {
+		if m.config.Image.IsNull() {
+			d.Append(m.modifyImage(ctx)...)
+		}
+	}
+
+	return d
+}
+
+func (m *serverReinstallModifier) modifyPrivateIP(ctx context.Context) diag.Diagnostics {
+	var d diag.Diagnostics
+
+	ips := make([]ipAddressFlatResourceModel, 0, len(m.plan.IpAddresses.Elements()))
+	diags := m.plan.IpAddresses.ElementsAs(ctx, &ips, false)
+	d.Append(diags...)
+	if d.HasError() {
+		return d
+	}
+
+	ipsAttrs := make([]attr.Value, 0, len(ips))
+
+	for i := range ips {
+		if ips[i].Type.ValueString() == "private-ip" {
+			ips[i].Address = types.StringUnknown()
+			ips[i].Id = types.StringUnknown()
+			ips[i].CIDR = types.StringUnknown()
+		}
+
+		ipAttr, ipDiags := types.ObjectValueFrom(ctx, ips[i].AttributeTypes(), ips[i])
+		d.Append(ipDiags...)
+		if d.HasError() {
+			return d
+		}
+
+		ipsAttrs = append(ipsAttrs, ipAttr)
+	}
+
+	ipsTf, ipsDiags := types.SetValue(types.ObjectType{AttrTypes: ipAddressFlatResourceModel{}.AttributeTypes()}, ipsAttrs)
+	d.Append(ipsDiags...)
+	if d.HasError() {
+		return d
+	}
+
+	m.plan.IpAddresses = ipsTf
+	return d
+}
+
+func (m *serverReinstallModifier) modifyImage(ctx context.Context) diag.Diagnostics {
+	var d diag.Diagnostics
+
+	img, err := m.defaultImage(ctx, m.plan.Plan.ValueString())
+	if err != nil {
+		d.AddError("No Default Plan Image",
+			fmt.Sprintf("Failed to get a default image for plan: %s.", err.Error()))
+		return d
+	}
+	m.plan.Image = types.StringValue(img)
+
+	return d
+}
+
+// defaultImage gets a default OS image for the given server plan.
+// Specifically, it tries to find the latest Ubuntu version,
+// with a fallback to a random image.
+func (m *serverReinstallModifier) defaultImage(ctx context.Context, plan string) (string, error) {
+	images, _, err := m.lister.List(ctx, plan, nil)
+	if err != nil {
+		return "", err
+	}
+
+	var newImage string
+	for _, image := range images {
+		// Try to pick the latest ubuntu version.
+		if strings.HasPrefix(image.Slug, "ubuntu") && image.Slug > newImage {
+			newImage = image.Slug
+		}
+	}
+
+	// If for some reason we couldn't find an image, try to fall back to the first
+	// one in the slice.
+	if newImage == "" {
+		if len(images) == 0 {
+			return "", fmt.Errorf("no images found for plan %q", plan)
+		}
+		newImage = images[0].Slug
+	}
+
+	return newImage, nil
 }

--- a/internal/provider/server_modifier_test.go
+++ b/internal/provider/server_modifier_test.go
@@ -1,0 +1,620 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"regexp"
+	"testing"
+
+	"github.com/cherryservers/cherrygo/v4"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newReinstallAttributeCases() []struct {
+	name string
+	plan serverResourceModel
+} {
+	return []struct {
+		name string
+		plan serverResourceModel
+	}{
+		{
+			name: "planned image",
+			plan: newServerModel(func(m *serverResourceModel) {
+				m.Image = types.StringValue("test")
+			}),
+		},
+		{
+			name: "planned os_partition_size",
+			plan: newServerModel(func(m *serverResourceModel) {
+				m.OSPartitionSize = types.Int64Value(1)
+			}),
+		},
+		{
+			name: "planned ssh_key_ids",
+			plan: newServerModel(func(m *serverResourceModel) {
+				m.SSHKeyIds = types.SetValueMust(types.StringType, []attr.Value{types.StringValue("1")})
+			}),
+		},
+		{
+			name: "planned user_data",
+			plan: newServerModel(func(m *serverResourceModel) {
+				m.UserData = types.StringValue("test")
+			}),
+		},
+		{
+			name: "planned ipxe",
+			plan: newServerModel(func(m *serverResourceModel) {
+				m.IPXE = types.StringValue("test")
+			}),
+		},
+		{
+			name: "planned persist_ipxe",
+			plan: newServerModel(func(m *serverResourceModel) {
+				m.PersistIPXE = types.BoolValue(true)
+			}),
+		},
+	}
+}
+
+func TestReinstallModifierDoesNotRequireAllowReinstallForCreation(t *testing.T) {
+	for _, tc := range newReinstallAttributeCases() {
+		r := serverResource{client: &cherrygo.Client{}}
+		s := resourceSchema(t, &r)
+
+		req := resource.ModifyPlanRequest{
+			Plan:   planFromModelMust(t, tc.plan, s),
+			Config: configFromModelMust(t, tc.plan, s),
+		}
+		resp := newModifyResp(s)
+
+		t.Run(tc.name, func(t *testing.T) {
+			r.ModifyPlan(t.Context(), req, &resp)
+			require.Empty(t, resp.Diagnostics)
+		})
+	}
+}
+
+func TestServerReinstallModifierSetsUnknownPowerState(t *testing.T) {
+	for _, tc := range newReinstallAttributeCases() {
+		tc.plan.AllowReinstall = types.BoolValue(true)
+		t.Run(tc.name, func(t *testing.T) {
+			r := serverResource{client: &cherrygo.Client{}}
+			s := resourceSchema(t, &r)
+
+			req := newModifyReqFromModels(
+				t, newServerModel(nil), newServerModel(nil), tc.plan, s,
+			)
+			resp := newModifyResp(s)
+
+			r.ModifyPlan(t.Context(), req, &resp)
+			require.Empty(t, resp.Diagnostics)
+
+			var gotPlan serverResourceModel
+			require.Empty(t, resp.Plan.Get(t.Context(), &gotPlan))
+			assert.Equal(t, types.StringUnknown(), gotPlan.PowerState)
+		})
+	}
+}
+
+func TestServerReinstallModifierSetsUnknownPrivateIP(t *testing.T) {
+	ipModels := []ipAddressFlatResourceModel{
+		{
+			Id:            types.StringValue("uuid1"),
+			Type:          types.StringValue("primary-ip"),
+			Address:       types.StringValue("84.32.109.107"),
+			AddressFamily: types.Int64Value(4),
+			CIDR:          types.StringValue("84.32.109.0/25"),
+		},
+		{
+			Id:            types.StringValue("uuid2"),
+			Type:          types.StringValue("floating-ip"),
+			Address:       types.StringValue("84.32.109.108"),
+			AddressFamily: types.Int64Value(4),
+			CIDR:          types.StringValue("84.32.109.0/25"),
+		},
+		{
+			Id:            types.StringValue("uuid3"),
+			Type:          types.StringValue("private-ip"),
+			Address:       types.StringValue("10.190.213.5"),
+			AddressFamily: types.Int64Value(4),
+			CIDR:          types.StringValue("10.190.213.0/24"),
+			VLAN:          types.Int64Value(1235),
+		},
+		{
+			Id:            types.StringValue("uuid4"),
+			Type:          types.StringValue("private-ip"),
+			Address:       types.StringValue("10.190.213.6"),
+			AddressFamily: types.Int64Value(4),
+			CIDR:          types.StringValue("10.190.213.0/24"),
+			VLAN:          types.Int64Value(1236),
+		},
+	}
+
+	ipObjects := make([]attr.Value, len(ipModels))
+	for i := range ipModels {
+		ip, diags := types.ObjectValueFrom(t.Context(), ipModels[i].AttributeTypes(), ipModels[i])
+		require.Empty(t, diags)
+		ipObjects[i] = ip
+	}
+
+	ips := types.SetValueMust(types.ObjectType{AttrTypes: ipModels[0].AttributeTypes()}, ipObjects)
+
+	for _, tc := range newReinstallAttributeCases() {
+		tc.plan.AllowReinstall = types.BoolValue(true)
+		t.Run(tc.name, func(t *testing.T) {
+			tc.plan.IpAddresses = ips
+
+			r := serverResource{client: &cherrygo.Client{}}
+			s := resourceSchema(t, &r)
+
+			req := newModifyReqFromModels(
+				t, newServerModel(nil), newServerModel(nil), tc.plan, s,
+			)
+			resp := newModifyResp(s)
+
+			r.ModifyPlan(t.Context(), req, &resp)
+
+			require.Empty(t, resp.Diagnostics)
+
+			plannedIPs := make([]ipAddressFlatResourceModel, len(ipModels))
+			var gotPlan serverResourceModel
+			require.Empty(t, resp.Plan.Get(t.Context(), &gotPlan))
+			require.Empty(t, gotPlan.IpAddresses.ElementsAs(t.Context(), &plannedIPs, false))
+
+			assert.Contains(t, plannedIPs, ipModels[0])
+			assert.Contains(t, plannedIPs, ipModels[1])
+			assert.Contains(t, plannedIPs, ipAddressFlatResourceModel{
+				Id:            types.StringUnknown(),
+				Type:          types.StringValue("private-ip"),
+				Address:       types.StringUnknown(),
+				AddressFamily: types.Int64Value(4),
+				CIDR:          types.StringUnknown(),
+				VLAN:          types.Int64Value(1235),
+			})
+			assert.Contains(t, plannedIPs, ipAddressFlatResourceModel{
+				Id:            types.StringUnknown(),
+				Type:          types.StringValue("private-ip"),
+				Address:       types.StringUnknown(),
+				AddressFamily: types.Int64Value(4),
+				CIDR:          types.StringUnknown(),
+				VLAN:          types.Int64Value(1236),
+			})
+			assert.Len(t, plannedIPs, len(ipModels))
+		})
+	}
+}
+
+func TestServerReinstallModifierSetsSSHToEmptyWhenInstallingIPXE(t *testing.T) {
+	r := serverResource{client: &cherrygo.Client{}}
+	s := resourceSchema(t, &r)
+
+	state := newServerModel(func(m *serverResourceModel) {
+		m.Image = types.StringValue("not-ipxe")
+	})
+	plan := newServerModel(func(m *serverResourceModel) {
+		m.AllowReinstall = types.BoolValue(true)
+		m.IPXE = types.StringValue("test")
+		m.SSHKeyIds = types.SetValueMust(types.StringType, []attr.Value{types.StringValue("1")})
+	})
+	req := newModifyReqFromModels(t, newServerModel(nil), state, plan, s)
+	resp := newModifyResp(s)
+
+	r.ModifyPlan(t.Context(), req, &resp)
+
+	require.Empty(t, resp.Diagnostics)
+
+	var gotPlan serverResourceModel
+	require.Empty(t, resp.Plan.Get(t.Context(), &gotPlan))
+	want := types.SetValueMust(types.StringType, []attr.Value{})
+
+	assert.Equal(t, want, gotPlan.SSHKeyIds)
+}
+
+func TestServerReinstallModifierRetainsSSHWhenNonIPXE(t *testing.T) {
+	r := serverResource{client: &cherrygo.Client{}}
+	s := resourceSchema(t, &r)
+
+	state := newServerModel(func(m *serverResourceModel) {
+		m.Image = types.StringValue("not-ipxe")
+	})
+	plan := newServerModel(func(m *serverResourceModel) {
+		m.AllowReinstall = types.BoolValue(true)
+		m.Image = types.StringValue("another-not-ipxe")
+		m.SSHKeyIds = types.SetValueMust(types.StringType, []attr.Value{types.StringValue("1")})
+	})
+	req := newModifyReqFromModels(t, newServerModel(nil), state, plan, s)
+	resp := newModifyResp(s)
+
+	r.ModifyPlan(t.Context(), req, &resp)
+
+	require.Empty(t, resp.Diagnostics)
+
+	var gotPlan serverResourceModel
+	require.Empty(t, resp.Plan.Get(t.Context(), &gotPlan))
+	want := types.SetValueMust(types.StringType, []attr.Value{types.StringValue("1")})
+
+	assert.Equal(t, want, gotPlan.SSHKeyIds)
+}
+
+type fakeImgLister struct {
+	sendImages []cherrygo.Image
+	sendErr    error
+	gotPlan    string
+}
+
+func (l *fakeImgLister) List(_ context.Context, plan string, _ *cherrygo.GetOptions) ([]cherrygo.Image, *cherrygo.Response, error) {
+	l.gotPlan = plan
+	return l.sendImages, nil, l.sendErr
+}
+
+func TestServerReinstallModifierSetsDefaultImageWhenInstallingNonIPXE(t *testing.T) {
+	cases := []struct {
+		name      string
+		lister    fakeImgLister
+		wantImage string
+	}{
+		{
+			name: "gets latest ubuntu if available",
+			lister: fakeImgLister{
+				sendImages: []cherrygo.Image{
+					{Slug: "some-img"},
+					{Slug: "ubuntu_24_04_64bit"},
+					{Slug: "ubuntu_26_04_64bit"},
+					{Slug: "another-img"},
+				},
+				sendErr: nil,
+			},
+			wantImage: "ubuntu_26_04_64bit",
+		},
+		{
+			name: "gets first if no ubuntu",
+			lister: fakeImgLister{
+				sendImages: []cherrygo.Image{
+					{Slug: "some-img"},
+					{Slug: "another-img"},
+				},
+				sendErr: nil,
+			},
+			wantImage: "some-img",
+		},
+	}
+
+	for _, tc := range cases {
+		r := serverResource{client: &cherrygo.Client{Images: &tc.lister}}
+		s := resourceSchema(t, &r)
+
+		state := newServerModel(func(m *serverResourceModel) {
+			m.Image = types.StringValue("custom_ipxe_install")
+		})
+		plan := newServerModel(func(m *serverResourceModel) {
+			m.AllowReinstall = types.BoolValue(true)
+			m.Plan = types.StringValue("test-plan")
+		})
+		req := newModifyReqFromModels(t, newServerModel(nil), state, plan, s)
+		resp := newModifyResp(s)
+
+		t.Run(tc.name, func(t *testing.T) {
+			r.ModifyPlan(t.Context(), req, &resp)
+			require.Empty(t, resp.Diagnostics)
+
+			var gotPlan serverResourceModel
+			require.Empty(t, resp.Plan.Get(t.Context(), &gotPlan))
+
+			assert.Equal(t, tc.wantImage, gotPlan.Image.ValueString())
+			assert.Equal(t, "test-plan", tc.lister.gotPlan)
+		})
+	}
+}
+
+func TestServerReinstallModifierReturnsErrorWhenDefaultImageFails(t *testing.T) {
+	cases := []struct {
+		name   string
+		lister fakeImgLister
+	}{
+		{
+			name: "when image list error",
+			lister: fakeImgLister{
+				sendErr: errors.New("test-error"),
+			},
+		},
+		{
+			name: "when no images",
+			lister: fakeImgLister{
+				sendImages: []cherrygo.Image{},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		r := serverResource{client: &cherrygo.Client{Images: &tc.lister}}
+		s := resourceSchema(t, &r)
+
+		state := newServerModel(func(m *serverResourceModel) {
+			m.Image = types.StringValue("custom_ipxe_install")
+		})
+		plan := newServerModel(func(m *serverResourceModel) {
+			m.AllowReinstall = types.BoolValue(true)
+			m.Plan = types.StringValue("test-plan")
+		})
+		req := newModifyReqFromModels(t, newServerModel(nil), state, plan, s)
+		resp := newModifyResp(s)
+
+		t.Run(tc.name, func(t *testing.T) {
+			r.ModifyPlan(t.Context(), req, &resp)
+			diags := resp.Diagnostics
+
+			require.Len(t, diags, 1)
+			assert.Regexp(
+				t,
+				regexp.MustCompile("Failed to get a default image for plan"),
+				diags[0].Detail(),
+			)
+
+			assert.Equal(t, "test-plan", tc.lister.gotPlan)
+		})
+	}
+}
+
+func TestServerReinstallModifierDoesNotOverrideImageWhenInstallingNonIPXE(t *testing.T) {
+	r := serverResource{client: &cherrygo.Client{}}
+	s := resourceSchema(t, &r)
+
+	state := newServerModel(func(m *serverResourceModel) {
+		m.Image = types.StringValue("custom_ipxe_install")
+	})
+	config := newServerModel(func(m *serverResourceModel) {
+		m.Image = types.StringValue("test-img")
+	})
+	plan := newServerModel(func(m *serverResourceModel) {
+		m.AllowReinstall = types.BoolValue(true)
+		m.Plan = types.StringValue("test-plan")
+		m.Image = types.StringValue("test-img")
+	})
+	req := newModifyReqFromModels(t, config, state, plan, s)
+	resp := newModifyResp(s)
+
+	r.ModifyPlan(t.Context(), req, &resp)
+	require.Empty(t, resp.Diagnostics)
+
+	var gotPlan serverResourceModel
+	require.Empty(t, resp.Plan.Get(t.Context(), &gotPlan))
+	assert.Equal(t, "test-img", gotPlan.Image.ValueString())
+}
+
+func TestServerModifyPlanReturnsErrorWithInvalidRequests(t *testing.T) {
+	r := serverResource{client: &cherrygo.Client{}}
+	s := resourceSchema(t, &r)
+	okVal := planFromModelMust(t, newServerModel(nil), s).Raw
+
+	cases := []struct {
+		name                         string
+		configRaw, planRaw, stateRaw tftypes.Value
+	}{
+		{
+			name:      "bad config",
+			configRaw: tftypes.NewValue(tftypes.Number, 1),
+			planRaw:   okVal,
+			stateRaw:  okVal,
+		},
+		{
+			name:      "bad plan",
+			configRaw: okVal,
+			planRaw:   tftypes.NewValue(tftypes.Number, 1),
+			stateRaw:  okVal,
+		},
+		{
+			name:      "bad state",
+			configRaw: okVal,
+			planRaw:   okVal,
+			stateRaw:  tftypes.NewValue(tftypes.Number, 1),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := resource.ModifyPlanRequest{
+				Plan:   tfsdk.Plan{Schema: s, Raw: tc.planRaw},
+				Config: tfsdk.Config{Schema: s, Raw: tc.configRaw},
+				State:  tfsdk.State{Schema: s, Raw: tc.stateRaw},
+			}
+
+			resp := newModifyResp(s)
+
+			r.ModifyPlan(t.Context(), req, &resp)
+			diags := resp.Diagnostics
+			require.Len(t, diags, 1)
+			assert.Regexp(
+				t, regexp.MustCompile(`trying to convert`), diags[0].Detail(),
+			)
+		})
+	}
+}
+
+func TestServerModifyPlanSkipsDeleteRequests(t *testing.T) {
+	r := serverResource{client: &cherrygo.Client{}}
+	s := resourceSchema(t, &r)
+
+	var req resource.ModifyPlanRequest
+	resp := newModifyResp(s)
+
+	r.ModifyPlan(t.Context(), req, &resp)
+	require.Empty(t, resp.Diagnostics)
+	assert.True(t, resp.Plan.Raw.IsNull())
+}
+
+func TestServerModifyPlanSetsIPXEImageWhenIPXEIsPlanned(t *testing.T) {
+	r := serverResource{client: &cherrygo.Client{}}
+	s := resourceSchema(t, &r)
+	planModel := newServerModel(func(m *serverResourceModel) {
+		m.AllowReinstall = types.BoolValue(true)
+		m.IPXE = types.StringValue("test")
+	})
+
+	cases := []struct {
+		name  string
+		state tfsdk.State
+	}{
+		{
+			name:  "creation request",
+			state: tfsdk.State{Schema: s},
+		},
+		{
+			name:  "update request",
+			state: stateFromModelMust(t, newServerModel(nil), s),
+		},
+	}
+
+	for _, tc := range cases {
+		req := resource.ModifyPlanRequest{
+			State:  tc.state,
+			Config: configFromModelMust(t, newServerModel(nil), s),
+			Plan:   planFromModelMust(t, planModel, s),
+		}
+		resp := newModifyResp(s)
+
+		t.Run(tc.name, func(t *testing.T) {
+			r.ModifyPlan(t.Context(), req, &resp)
+			require.Empty(t, resp.Diagnostics)
+
+			var gotPlan serverResourceModel
+			require.Empty(t, resp.Plan.Get(t.Context(), &gotPlan))
+
+			assert.Equal(t, "custom_ipxe_install", gotPlan.Image.ValueString())
+		})
+	}
+}
+
+func TestServerModifyPlanDoesNothingWhenUpdatingWithoutReinstall(t *testing.T) {
+	r := serverResource{client: &cherrygo.Client{}}
+	s := resourceSchema(t, &r)
+	planModel := newServerModel(func(m *serverResourceModel) {
+		m.Hostname = types.StringValue("test")
+	})
+	stateModel := newServerModel(func(m *serverResourceModel) {
+		m.Hostname = types.StringValue("old")
+	})
+	req := newModifyReqFromModels(t, planModel, stateModel, planModel, s)
+	resp := newModifyResp(s)
+
+	r.ModifyPlan(t.Context(), req, &resp)
+	require.Empty(t, resp.Diagnostics)
+
+	var gotPlan serverResourceModel
+	require.Empty(t, resp.Plan.Get(t.Context(), &gotPlan))
+
+	assert.Equal(t, planModel, gotPlan)
+}
+
+func configFromModelMust(t *testing.T, m any, s schema.Schema) tfsdk.Config {
+	t.Helper()
+
+	// tfsdk.Config doesn't have Set, due to its immutable nature,
+	// so we need this workaround.
+	plan := tfsdk.Plan{
+		Schema: s,
+	}
+	diags := plan.Set(t.Context(), m)
+	require.Empty(t, diags)
+
+	return tfsdk.Config{Raw: plan.Raw, Schema: s}
+}
+
+func planFromModelMust(t *testing.T, m any, s schema.Schema) tfsdk.Plan {
+	t.Helper()
+
+	plan := tfsdk.Plan{
+		Schema: s,
+	}
+	diags := plan.Set(t.Context(), m)
+	require.Empty(t, diags)
+
+	return plan
+}
+
+func stateFromModelMust(t *testing.T, m any, s schema.Schema) tfsdk.State {
+	t.Helper()
+
+	state := tfsdk.State{
+		Schema: s,
+	}
+	diags := state.Set(t.Context(), m)
+	require.Empty(t, diags)
+
+	return state
+}
+
+func resourceSchema(t *testing.T, r resource.Resource) schema.Schema {
+	t.Helper()
+
+	var resp resource.SchemaResponse
+	r.Schema(t.Context(), resource.SchemaRequest{}, &resp)
+	return resp.Schema
+}
+
+// newServerModel runs f over a model with zero valued fields set to null,
+// as required for a valid model, and returns the model. Nil f is ignored.
+func newServerModel(f func(m *serverResourceModel)) serverResourceModel {
+	ipsType := ipAddressFlatResourceModel{}.AttributeTypes()
+	pricingType := serverPricingModel{}.AttributeTypes()
+	timeoutsType := map[string]attr.Type{
+		"create": types.StringType,
+		"update": types.StringType,
+	}
+
+	m := serverResourceModel{
+		Plan:                types.StringNull(),
+		ProjectId:           types.Int64Null(),
+		Region:              types.StringNull(),
+		Hostname:            types.StringNull(),
+		Image:               types.StringNull(),
+		SSHKeyIds:           types.SetNull(types.StringType),
+		ExtraIPAddressesIds: types.SetNull(types.StringType),
+		ConfigureIPv6:       types.BoolNull(),
+		IPAddressesIds:      types.SetNull(types.StringType),
+		UserData:            types.StringNull(),
+		IPXE:                types.StringNull(),
+		PersistIPXE:         types.BoolNull(),
+		Tags:                types.MapNull(types.StringType),
+		SpotInstance:        types.BoolNull(),
+		OSPartitionSize:     types.Int64Null(),
+		PowerState:          types.StringNull(),
+		State:               types.StringNull(),
+		IpAddresses:         types.SetNull(types.ObjectType{AttrTypes: ipsType}),
+		Id:                  types.StringNull(),
+		Timeouts:            timeouts.Value{Object: types.ObjectNull(timeoutsType)},
+		AllowReinstall:      types.BoolNull(),
+		Cycle:               types.StringNull(),
+		DiscountCode:        types.StringNull(),
+		Pricing:             types.ObjectNull(pricingType),
+	}
+
+	if f != nil {
+		f(&m)
+	}
+	return m
+}
+
+func newModifyReqFromModels[T serverResourceModel](t *testing.T, config, state, plan T, s schema.Schema) resource.ModifyPlanRequest {
+	return resource.ModifyPlanRequest{
+		Config: configFromModelMust(t, config, s),
+		Plan:   planFromModelMust(t, plan, s),
+		State:  stateFromModelMust(t, state, s),
+	}
+}
+
+func newModifyResp(s schema.Schema) resource.ModifyPlanResponse {
+	return resource.ModifyPlanResponse{
+		Plan: tfsdk.Plan{
+			Schema: s,
+		},
+	}
+}

--- a/internal/provider/server_resource.go
+++ b/internal/provider/server_resource.go
@@ -576,36 +576,49 @@ func (r *serverResource) ModifyPlan(ctx context.Context, req resource.ModifyPlan
 	}
 
 	if requiresReinstall(plan, state) {
-		// Power state can be unpredictable when re-installing.
-		plan.PowerState = types.StringUnknown()
-
-		resp.Diagnostics.Append(modifyPrivateIP(ctx, &plan)...)
+		resp.Diagnostics.Append(r.modifyReinstall(ctx, &plan, state, config)...)
 		if resp.Diagnostics.HasError() {
 			return
-		}
-
-		// Ensure we don't pass SSH keys, when reinstalling non-iPXE -> iPXE,
-		// since SSH keys use state, if unconfigured.
-		if !plan.IPXE.IsNull() && state.Image.ValueString() != ipxeImage {
-			plan.SSHKeyIds = types.SetValueMust(types.StringType, []attr.Value{})
-		}
-	}
-
-	// If we need to reinstall an iPXE server into a non-iPXE server, we may need
-	// to find a default image, if the user didn't configure one.
-	if requiresReinstall(plan, state) && plan.IPXE.IsNull() && state.Image.ValueString() == ipxeImage {
-		serverPlan := plan.Plan
-
-		if config.Image.IsNull() {
-			resp.Diagnostics.Append(r.modifyImage(ctx, serverPlan, &plan)...)
-			if resp.Diagnostics.HasError() {
-				return
-			}
 		}
 	}
 
 	diags := resp.Plan.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
+}
+
+func (r *serverResource) modifyReinstall(
+	ctx context.Context,
+	plan *serverResourceModel,
+	state, config serverResourceModel,
+) diag.Diagnostics {
+	var d diag.Diagnostics
+
+	// Power state can be unpredictable when re-installing.
+	plan.PowerState = types.StringUnknown()
+
+	// Private IP may change on reinstall.
+	d.Append(modifyPrivateIP(ctx, plan)...)
+	if d.HasError() {
+		return d
+	}
+
+	// Ensure we don't pass SSH keys, when reinstalling non-iPXE -> iPXE,
+	// since SSH keys use state, if unconfigured.
+	if !plan.IPXE.IsNull() && state.Image.ValueString() != ipxeImage {
+		plan.SSHKeyIds = types.SetValueMust(types.StringType, []attr.Value{})
+	}
+
+	// If we need to reinstall iPXE -> non-iPXE, we may need
+	// to find a default image, if the user didn't configure one.
+	if plan.IPXE.IsNull() && state.Image.ValueString() == ipxeImage {
+		serverPlan := plan.Plan
+
+		if config.Image.IsNull() {
+			d.Append(r.modifyImage(ctx, serverPlan, plan)...)
+		}
+	}
+
+	return d
 }
 
 func modifyPrivateIP(ctx context.Context, plan *serverResourceModel) diag.Diagnostics {

--- a/internal/provider/server_resource.go
+++ b/internal/provider/server_resource.go
@@ -249,7 +249,9 @@ func (r *serverResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				Sensitive: true,
 			},
 			"persist_ipxe": schema.BoolAttribute{
-				Description: "Enable persisting the universal iPXE image between server boots. See https://www.cherryservers.com/knowledge/docs/compute/configuration-management/ipxe#how-ipxe-works-with-cherry-servers.",
+				Description: "Enable persisting the universal iPXE image between server boots. " +
+				 "See https://www.cherryservers.com/knowledge/docs/compute/configuration-management/ipxe#how-ipxe-works-with-cherry-servers. " +
+				 "Updating this attribute requires a server re-install.",
 				Optional:    true,
 				Validators: []validator.Bool{
 					boolvalidator.AlsoRequires(path.MatchRoot("ipxe")),
@@ -260,7 +262,6 @@ func (r *serverResource) Schema(ctx context.Context, req resource.SchemaRequest,
 			},
 			"image": schema.StringAttribute{
 				Description: "Slug of the server operating system. " +
-					"Updating this attribute requires a server re-install. " +
 					"If iPXE is used, this must be set to `" + ipxeImage +
 					"` or left unconfigured, in which case the provider will set the " +
 					"correct image. " +

--- a/internal/provider/server_resource.go
+++ b/internal/provider/server_resource.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"slices"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/cherryservers/cherrygo/v4"
@@ -512,35 +511,6 @@ func (r *serverResource) ValidateConfig(ctx context.Context, req resource.Valida
 	}
 }
 
-// defaultImage gets a default OS image for the given server plan.
-// Specifically, it tries to find the latest Ubuntu version,
-// with a fallback to a random image.
-func (r *serverResource) defaultImage(ctx context.Context, plan string) (string, error) {
-	images, _, err := r.client.Images.List(ctx, plan, nil)
-	if err != nil {
-		return "", err
-	}
-
-	var newImage string
-	for _, image := range images {
-		// Try to pick the latest ubuntu version.
-		if strings.HasPrefix(image.Slug, "ubuntu") && image.Slug > newImage {
-			newImage = image.Slug
-		}
-	}
-
-	// If for some reason we couldn't find an image, try to fall back to the first
-	// one in the slice.
-	if newImage == "" {
-		if len(images) == 0 {
-			return "", fmt.Errorf("no images found for plan %q", plan)
-		}
-		newImage = images[0].Slug
-	}
-
-	return newImage, nil
-}
-
 func (r *serverResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
 	// Skip on delete.
 	if req.Plan.Raw.IsNull() {
@@ -576,7 +546,13 @@ func (r *serverResource) ModifyPlan(ctx context.Context, req resource.ModifyPlan
 	}
 
 	if requiresReinstall(plan, state) {
-		resp.Diagnostics.Append(r.modifyReinstall(ctx, &plan, state, config)...)
+		modifier := serverReinstallModifier{
+			plan:   &plan,
+			state:  state,
+			config: config,
+			lister: r.client.Images,
+		}
+		resp.Diagnostics.Append(modifier.modify(ctx)...)
 		if resp.Diagnostics.HasError() {
 			return
 		}
@@ -584,93 +560,6 @@ func (r *serverResource) ModifyPlan(ctx context.Context, req resource.ModifyPlan
 
 	diags := resp.Plan.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
-}
-
-func (r *serverResource) modifyReinstall(
-	ctx context.Context,
-	plan *serverResourceModel,
-	state, config serverResourceModel,
-) diag.Diagnostics {
-	var d diag.Diagnostics
-
-	// Power state can be unpredictable when re-installing.
-	plan.PowerState = types.StringUnknown()
-
-	// Private IP may change on reinstall.
-	d.Append(modifyPrivateIP(ctx, plan)...)
-	if d.HasError() {
-		return d
-	}
-
-	// Ensure we don't pass SSH keys, when reinstalling non-iPXE -> iPXE,
-	// since SSH keys use state, if unconfigured.
-	if !plan.IPXE.IsNull() && state.Image.ValueString() != ipxeImage {
-		plan.SSHKeyIds = types.SetValueMust(types.StringType, []attr.Value{})
-	}
-
-	// If we need to reinstall iPXE -> non-iPXE, we may need
-	// to find a default image, if the user didn't configure one.
-	if plan.IPXE.IsNull() && state.Image.ValueString() == ipxeImage {
-		serverPlan := plan.Plan
-
-		if config.Image.IsNull() {
-			d.Append(r.modifyImage(ctx, serverPlan, plan)...)
-		}
-	}
-
-	return d
-}
-
-func modifyPrivateIP(ctx context.Context, plan *serverResourceModel) diag.Diagnostics {
-	var d diag.Diagnostics
-
-	ips := make([]ipAddressFlatResourceModel, 0, len(plan.IpAddresses.Elements()))
-	diags := plan.IpAddresses.ElementsAs(ctx, &ips, false)
-	d.Append(diags...)
-	if d.HasError() {
-		return d
-	}
-
-	ipsAttrs := make([]attr.Value, 0, len(ips))
-
-	for i := range ips {
-		if ips[i].Type.ValueString() == "private-ip" {
-			ips[i].Address = types.StringUnknown()
-			ips[i].Id = types.StringUnknown()
-			ips[i].CIDR = types.StringUnknown()
-		}
-
-		ipAttr, ipDiags := types.ObjectValueFrom(ctx, ips[i].AttributeTypes(), ips[i])
-		d.Append(ipDiags...)
-		if d.HasError() {
-			return d
-		}
-
-		ipsAttrs = append(ipsAttrs, ipAttr)
-	}
-
-	ipsTf, ipsDiags := types.SetValue(types.ObjectType{AttrTypes: ipAddressFlatResourceModel{}.AttributeTypes()}, ipsAttrs)
-	d.Append(ipsDiags...)
-	if d.HasError() {
-		return d
-	}
-
-	plan.IpAddresses = ipsTf
-	return d
-}
-
-func (r *serverResource) modifyImage(ctx context.Context, serverPlan types.String, plan *serverResourceModel) diag.Diagnostics {
-	var d diag.Diagnostics
-
-	img, err := r.defaultImage(ctx, serverPlan.ValueString())
-	if err != nil {
-		d.AddError("No Default Plan Image",
-			fmt.Sprintf("Failed to get a default image for plan: %s.", err.Error()))
-		return d
-	}
-	plan.Image = types.StringValue(img)
-
-	return d
 }
 
 func (r *serverResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {


### PR DESCRIPTION
Adds unit tests for the server resource plan modification method. With the recently increased complexity of server plan modifications, due to additional re-installation and iPXE options, it's becoming a struggle to have enough acceptance test coverage. Should there be more server deployment options in the future, which is quite likely, this will only become more painful.

This refactors the server plan modification into a clearer structure and adds comprehensive unit tests for it.

Acceptance test run: https://github.com/cherryservers/terraform-provider-cherryservers/actions/runs/34193746645